### PR TITLE
Updates from 1 March working session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Linkerd 2.13 Dynamic Request Routing and Circuit Breaking
+# Gateway API 1.0 Workshop
 
-This is the documentation - and executable code! - for the Service Mesh
-Academy workshop about what's coming in Linkerd 2.13. The easiest way to use
-this file is to execute it with [demosh].
+This is the documentation - and executable code! - for the Gateway API 1.0
+Workshop at KubeCon Paris 2024. The easiest way to use this file is to execute
+it with [demosh].
 
 Things in Markdown comments are safe to ignore when reading this later. When
 executing this with [demosh], things after the horizontal rule below (which
@@ -10,24 +10,17 @@ is just before a commented `@SHOW` directive) will get displayed.
 
 [demosh]: https://github.com/BuoyantIO/demosh
 
-For this workshop, you'll need a running Kubernetes cluster set up with
-Linkerd, Emissary, and the Faces app. You can use `create-cluster.sh` to
-create an appropriate `k3d` cluster, and `setup-demo.sh` to initialize it.
+For this workshop, you'll need a running, empty, Kubernetes cluster. You can
+use `create-cluster.sh` to create a k3d cluster that will work.
 
 <!-- set -e >
 <!-- @import demosh/check-requirements.sh -->
-<!-- @import demosh/demo-tools.sh -->
 
 <!-- @start_livecast -->
 
 ```bash
 BAT_STYLE="grid,numbers"
 ```
-
-You'll also want two web browsers running pointing to the Faces app at
-(assuming you used `create-cluster.sh` to set up your cluster)
-https://localhost/faces/ -- one normal one, and one using ModHeader or the
-like to set `X-Faces-User: testuser` for the canarying test.
 
 ---
 <!-- @SHOW -->

--- a/envoy-gateway/gatewayclass-and-gateway.yaml
+++ b/envoy-gateway/gatewayclass-and-gateway.yaml
@@ -9,7 +9,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
-  name: eg
+  name: ingress
 spec:
   gatewayClassName: envoy-gateway-class
   listeners:

--- a/k8s/01-base/face-route.yaml
+++ b/k8s/01-base/face-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: faces
 spec:
   parentRefs:
-    - name: eg
+    - name: ingress
       namespace: default
   rules:
   - matches:

--- a/k8s/01-base/gui-route.yaml
+++ b/k8s/01-base/gui-route.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: faces
 spec:
   parentRefs:
-    - name: eg
+    - name: ingress
       namespace: default
   rules:
   - matches:

--- a/k8s/02-canary/color-canary-10.yaml
+++ b/k8s/02-canary/color-canary-10.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy.linkerd.io/v1beta2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: color-canary

--- a/k8s/03-abtest/smiley-ab.yaml
+++ b/k8s/03-abtest/smiley-ab.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy.linkerd.io/v1beta2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: smiley-a-b

--- a/setup-demo.sh
+++ b/setup-demo.sh
@@ -86,5 +86,9 @@ helm install faces \
 # After that, wait for the Faces application to be ready...
 kubectl rollout status -n faces deploy
 
+# In the demo, at least talk about the GatewayClass and Gateway ...maybe show
+# installing these as well? probably makes sense to just talk about it though
+
 # ...after which we can install the Faces HTTPRoutes.
-kubectl apply -f k8s/01-base
+# No -- show this in the demo
+# kubectl apply -f k8s/01-base

--- a/setup-demo.sh
+++ b/setup-demo.sh
@@ -77,7 +77,9 @@ kubectl rollout status -n envoy-gateway-system deploy
 helm install faces \
      -n faces \
      oci://ghcr.io/buoyantio/faces-chart \
-     --version 1.0.0-alpha.1
+     --version 1.0.0-alpha.1 \
+     --set face.errorFraction=0 \
+     --set backend.errorFraction=0
 
 # Let's also set
 


### PR DESCRIPTION
Review commit by commit.

- README updates (including dropping the unneeded demo-tools @import)
- Start with Faces running without errors
- Rename the GatewayClass to "ingress"
- Use Gateway API v1beta1 routes
- Don't install the Faces HTTPRoutes in setup-demo.sh.
