### PR TITLE
Fix apiVersion of smiley route resources

### DIFF
--- a/k8s/04-timeouts/smiley-timeout-istio.yaml
+++ b/k8s/04-timeouts/smiley-timeout-istio.yaml
@@ -1,4 +1,4 @@
-tapiVersion: policy.linkerd.io/v1beta3
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: smiley-timeout


### PR DESCRIPTION
~With timeouts now implemented, I guess we don't need the Linkerd-specific HTTPRoutes anymore.~

Also fixes a small typo in the `smiley-timeout` HTTPRoute resource.